### PR TITLE
Change from serial port to GPIO pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ Notes:
 
 ![example by week plot](./example_by_week_plot.png)
 
-## Installation on `ws01`
+## Installation on Raspberry Pi
 
-We have a serial read sensor to query the door state.
-It is located in our `ws01` Linux pc.
+We have a Raspberry Pi to query the door state using GPIO pins.
+It is located on top of the display shelf next to the door to the FSV room.
 It uses the script `misc/update-status.sh`.
-This script will be started every minute by the systemd timer in `misc/`.
+Connect GPIO2 and GPIO27 to the sensor, and add a 10k resistor from GPIO27 to GND.
+This script will be run every minute by the systemd timer in `misc/`.
 To install the timer run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Notes:
 We have a Raspberry Pi to query the door state using GPIO pins.
 It is located on top of the display shelf next to the door to the FSV room.
 It uses the script `misc/update-status.sh`.
-Connect GPIO2 and GPIO27 to the sensor, and add a 10k resistor from GPIO27 to GND.
+Connect 3V3 and GPIO17 to the sensor, and add a 10k resistor from GPIO17 to GND.
+While not required, adding a 1k resistor before GPIO17 is recommended.
+It acts as a failsafe, protecting the RPi in case of configuration problems.
 This script will be run every minute by the systemd timer in `misc/`.
 To install the timer run:
 

--- a/misc/tuerstatus-onboot.sh
+++ b/misc/tuerstatus-onboot.sh
@@ -1,0 +1,6 @@
+echo "2" > /sys/class/gpio/export
+echo "27" > /sys/class/gpio/export
+echo "in" > /sys/class/gpio/gpio2/direction 
+echo "out" > /sys/class/gpio/gpio27/direction 
+echo "0" > /sys/class/gpio/gpio27/value
+echo "onboot done" > ~/gpiosetuplog

--- a/misc/tuerstatus-onboot.sh
+++ b/misc/tuerstatus-onboot.sh
@@ -1,6 +1,0 @@
-echo "2" > /sys/class/gpio/export
-echo "27" > /sys/class/gpio/export
-echo "in" > /sys/class/gpio/gpio2/direction 
-echo "out" > /sys/class/gpio/gpio27/direction 
-echo "0" > /sys/class/gpio/gpio27/value
-echo "onboot done" > ~/gpiosetuplog

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -12,15 +12,15 @@ KEY="$HOME/door.key"
 DOORSTATE_USER="tuerstatus"
 
 # GPIO input pin that reads from the sensor
-GPIO_IN_PIN="2"
+GPIO_IN_PIN="17"
 
 # invert logic?
 # false: switch closed = door closed
 # true: switch open = door closed 
-DOORSTATE_INVERTED="true"
+DOORSTATE_INVERTED="false"
 
 # GPIO output pin. Set to "" to disable (for example, if sensor is connected to 3V3)
-GPIO_OUT_PIN="27"
+GPIO_OUT_PIN=""
 # What value should be set on the output pin (ignored if $OUT_GPIO_PIN is "")
 GPIO_OUT_VALUE="0"
 

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -12,7 +12,7 @@ KEY="$HOME/door.key"
 DOORSTATE_USER="tuerstatus"
 
 # GPIO input pin that reads from the sensor
-IN_GPIO_PIN="2"
+GPIO_IN_PIN="2"
 
 # invert logic?
 # false: switch closed = door closed
@@ -20,9 +20,9 @@ IN_GPIO_PIN="2"
 DOORSTATE_INVERTED="true"
 
 # GPIO output pin. Set to 0 to disable (for example, if sensor is connected to 3V3)
-OUT_GPIO_PIN="27"
+GPIO_OUT_PIN="27"
 # What value should be set on the output pin (ignored if $OUT_GPIO_PIN is 0)
-OUT_GPIO_STATE="0"
+GPIO_OUT_VALUE="0"
 
 ###
 # script
@@ -53,7 +53,7 @@ function update_status() {
 function is_open() {
 	sleep 1
 
-	if [ $(cat /sys/class/gpio/gpio$IN_GPIO_PIN/value) == 0 ]; then
+	if [ $(cat /sys/class/gpio/gpio$GPIO_IN_PIN/value) == 0 ]; then
 		echo "${RETURN_SWITCH_CLOSED}"
 		return 0
 	else
@@ -70,7 +70,8 @@ n=0
 for i in `seq 0 9`; do
 	n=$(($n + $(is_open)))
 done
-#  check if more than 7 times out of 10 the result is "opened"
+
+# check if more than 7 times out of 10 the result is "opened"
 if [ $n -gt 7 ]; then
 	update_status "opened"
 else

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -68,9 +68,12 @@ function is_open() {
 # set up GPIOs
 if [ ! -d /sys/class/gpio/gpio$GPIO_IN_PIN ]; then
 	echo "$GPIO_IN_PIN" > /sys/class/gpio/export
-	echo "in" > /sys/class/gpio/gpio$GPIO_IN_PIN/direction
 	if [ -n "$GPIO_OUT_PIN" ]; then
 		echo "$GPIO_OUT_PIN" > /sys/class/gpio/export
+	fi
+	sleep 1
+	echo "in" > /sys/class/gpio/gpio$GPIO_IN_PIN/direction
+	if [ -n "$GPIO_OUT_PIN" ]; then
 		echo "out" > /sys/class/gpio/gpio$GPIO_OUT_PIN/direction
 		echo "$GPIO_OUT_VALUE" > /sys/class/gpio/gpio$GPIO_OUT_PIN/value
 	fi

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -3,14 +3,30 @@ set +e
 
 cd "$(dirname "${0}")"
 
+###
+# configuration
+###
+
 KEY="$HOME/door.key"
 
 DOORSTATE_USER="tuerstatus"
+
+# GPIO input pin that reads from the sensor
+IN_GPIO_PIN="2"
 
 # invert logic?
 # false: switch closed = door closed
 # true: switch open = door closed 
 DOORSTATE_INVERTED="true"
+
+# GPIO output pin. Set to 0 to disable (for example, if sensor is connected to 3V3)
+OUT_GPIO_PIN="27"
+# What value should be set on the output pin (ignored if $OUT_GPIO_PIN is 0)
+OUT_GPIO_STATE="0"
+
+###
+# script
+###
 
 if [ "${USER}" != "${DOORSTATE_USER}" ]; then
 	echo "[!] Please run this script as user ${DOORSTATE_USER}" 1>&2
@@ -18,8 +34,8 @@ if [ "${USER}" != "${DOORSTATE_USER}" ]; then
 fi
 
 if $DOORSTATE_INVERTED; then
-        RETURN_SWITCH_OPEN="0"
-        RETURN_SWITCH_CLOSED="1"
+	RETURN_SWITCH_OPEN="0"
+	RETURN_SWITCH_CLOSED="1"
 else
 	RETURN_SWITCH_OPEN="1"
 	RETURN_SWITCH_CLOSED="0"
@@ -27,8 +43,8 @@ fi
 RETURN_ERROR="0"
 
 function update_status() {
-        ../spaceapi/doorstate_client.py update --key "${KEY}" --state "${1}"
-        touch /mnt/ramdisk/tuerstatus.success
+	../spaceapi/doorstate_client.py update --key "${KEY}" --state "${1}"
+	touch /mnt/ramdisk/tuerstatus.success
 }
 
 # is door open?
@@ -37,7 +53,7 @@ function update_status() {
 function is_open() {
 	sleep 1
 
-	if [ $(cat /sys/class/gpio/gpio2/value) == 0 ]; then
+	if [ $(cat /sys/class/gpio/gpio$IN_GPIO_PIN/value) == 0 ]; then
 		echo "${RETURN_SWITCH_CLOSED}"
 		return 0
 	else

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -5,17 +5,15 @@ cd "$(dirname "${0}")"
 
 KEY="$HOME/door.key"
 
-# crontab doesn't set $USER, so use $UID for checking
-# 1001 = tuerstatus
-DOORSTATE_USER="1001"
+DOORSTATE_USER="tuerstatus"
 
 # invert logic?
 # false: switch closed = door closed
 # true: switch open = door closed 
 DOORSTATE_INVERTED="true"
 
-if [ "${UID}" != "${DOORSTATE_USER}" ]; then
-	echo "[!] Please run this script as user ID ${DOORSTATE_USER}" 1>&2
+if [ "${USER}" != "${DOORSTATE_USER}" ]; then
+	echo "[!] Please run this script as user ${DOORSTATE_USER}" 1>&2
 	exit 1
 fi
 

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -4,16 +4,29 @@ set +e
 cd "$(dirname "${0}")"
 
 KEY="$HOME/door.key"
-DOORSTATE_USER="tuerstatus"
+
+# crontab doesn't set $USER, so use $UID for checking
+# 1001 = tuerstatus
+DOORSTATE_USER="1001"
+
 # invert logic?
 # false: switch closed = door closed
 # true: switch open = door closed 
 DOORSTATE_INVERTED="true"
 
-if [ "${USER}" != "${DOORSTATE_USER}" ]; then
-    echo "[!] Please run this script as user ${DOORSTATE_USER}" 1>&2
-    exit 1
+if [ "${UID}" != "${DOORSTATE_USER}" ]; then
+	echo "[!] Please run this script as user ID ${DOORSTATE_USER}" 1>&2
+	exit 1
 fi
+
+if $DOORSTATE_INVERTED; then
+        RETURN_SWITCH_OPEN="0"
+        RETURN_SWITCH_CLOSED="1"
+else
+	RETURN_SWITCH_OPEN="1"
+	RETURN_SWITCH_CLOSED="0"
+fi
+RETURN_ERROR="0"
 
 function update_status() {
         ../spaceapi/doorstate_client.py update --key "${KEY}" --state "${1}"
@@ -22,36 +35,26 @@ function update_status() {
 
 # is door open?
 # echo "1" if open, "0" otherwise
-# return 1 on error
+# return 0 on error
 function is_open() {
-	{
-        if $DOORSTATE_INVERTED; then
-            RETURN_SWITCH_OPEN="0"
-            RETURN_SWITCH_CLOSED="1"
-        else
-            RETURN_SWITCH_OPEN="1"
-            RETURN_SWITCH_CLOSED="0"
-        fi
-        RETURN_ERROR="0"
-		sleep 1
-		# send "MOEP", check response
-		# read returns its prompt on stderr, therefore the redirect below.
-		read -t 1 -n4 -p "MOEP" ans || { echo $RETURN_SWITCH_OPEN; return 0; }
-		if [ "a$ans" == "aMOEP" ]; then
-			# response is MOEP -- switch is closed
-			echo $RETURN_SWITCH_CLOSED
-			return 0
-		fi;
-		# error
-		echo $RETURN_ERROR
-		return 1;
-	} < /dev/ttyS0 2> /dev/ttyS0
+	sleep 1
+
+	if [ $(cat /sys/class/gpio/gpio2/value) == 0 ]; then
+		echo "${RETURN_SWITCH_CLOSED}"
+		return 0
+	else
+		echo "${RETURN_SWITCH_OPEN}"
+		return 0
+	fi
+	# error
+	echo "${RETURN_ERROR}"
+	return 1
 }
 
 # retry ten times
 n=0
 for i in `seq 0 9`; do
-	n=$(($n + `is_open`))
+	n=$(($n + $(is_open)))
 done
 #  check if more than 7 times out of 10 the result is "opened"
 if [ $n -gt 7 ]; then

--- a/misc/update-status.sh
+++ b/misc/update-status.sh
@@ -19,9 +19,9 @@ GPIO_IN_PIN="2"
 # true: switch open = door closed 
 DOORSTATE_INVERTED="true"
 
-# GPIO output pin. Set to 0 to disable (for example, if sensor is connected to 3V3)
+# GPIO output pin. Set to "" to disable (for example, if sensor is connected to 3V3)
 GPIO_OUT_PIN="27"
-# What value should be set on the output pin (ignored if $OUT_GPIO_PIN is 0)
+# What value should be set on the output pin (ignored if $OUT_GPIO_PIN is "")
 GPIO_OUT_VALUE="0"
 
 ###
@@ -64,6 +64,18 @@ function is_open() {
 	echo "${RETURN_ERROR}"
 	return 1
 }
+
+# set up GPIOs
+if [ ! -d /sys/class/gpio/gpio$GPIO_IN_PIN ]; then
+	echo "$GPIO_IN_PIN" > /sys/class/gpio/export
+	echo "in" > /sys/class/gpio/gpio$GPIO_IN_PIN/direction
+	if [ -n "$GPIO_OUT_PIN" ]; then
+		echo "$GPIO_OUT_PIN" > /sys/class/gpio/export
+		echo "out" > /sys/class/gpio/gpio$GPIO_OUT_PIN/direction
+		echo "$GPIO_OUT_VALUE" > /sys/class/gpio/gpio$GPIO_OUT_PIN/value
+	fi
+	echo "GPIOs set up"
+fi
 
 # retry ten times
 n=0

--- a/misc/update_doorstate.timer
+++ b/misc/update_doorstate.timer
@@ -5,7 +5,6 @@ Documentation=https://github.com/fau-fablab/spaceapi/
 [Timer]
 OnCalendar=*-*-* *:*:00
 Persistent=true
-WakeSystem=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Since door status has been broken for a while after the serial on the RPi failed, gurkih and I tinkered a little with it today. Someone had already cut the serial wire and added a new header, so the layout might seem a little odd.
I also changed the check from the user name to the user ID so the update script can be started with cronjob (I don't know how it was done before?)
This script is running on the RPi in the lab already and seems to be working fine.